### PR TITLE
Change args to belong to individual commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 serde = { version = "1.0.203", features = ["derive"] }
-clap = { version = "4.5.4", features = ["derive", "cargo"] }
+clap = { version = "4.5.44", features = ["derive", "cargo"] }
 srtlib = "0.1.9"
 once_cell = "1.19.0"
 scraper = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subbub"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,11 @@
 - create subtitles from audio using whisper ([which has been added to ffmpeg](https://news.ycombinator.com/item?id=44886647))
 - translate subtitles using DeepL or similar
   - supply API key as a CLI argument
+  - because subtitles between e.g., Japanese and English are structured differently
+    - first merge all subtitles less than say, 500ms apart (showed on-screen consecutively because they're part of the same line)
+    - then translate these merged subtitles
+    - now the translated subtitles are too long, so split them again into smaller chunks
+    - this will not work well if multiple characters are talking
 
 ## Notes
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@
     - then translate these merged subtitles
     - now the translated subtitles are too long, so split them again into smaller chunks
     - this will not work well if multiple characters are talking
+- a "release" github action that auto-builds binaries for Windows, macOS, and Linux and creates a release page
 
 ## Notes
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # Todo
 
-- refactor input/output to be groups of arguments that are mutually exclusive; e.g., you specify a video file's sub track, a subtitle file, or a directory, but not more than one (currently you specify _whatever_ and it just tries to do the right thing)
 - add alternative subtitle syncing options
   - shift forward/back by h:m:s:ms
   - sync to audio
@@ -8,8 +7,11 @@
 - update arguments to allow selecting _exactly one_ of the subtitle syncing options
 - split add-dual-subs into add-synced-subs and add-dual-subs
 - add command to do both of the above (add-and-combine-subs?)
+- create subtitles from audio using whisper ([which has been added to ffmpeg](https://news.ycombinator.com/item?id=44886647))
+- translate subtitles using DeepL or similar
+  - supply API key as a CLI argument
 
-# Notes
+## Notes
 
 - alternative sync solutions
   - ffsubsync with no reference attempts to use audio

--- a/src/bin/subbub.rs
+++ b/src/bin/subbub.rs
@@ -2,22 +2,18 @@
 
 use itertools::Itertools;
 use rayon::prelude::*;
-use rayon::str::Bytes;
-use std::f32::consts::E;
+use std::fs;
 use std::io::Write;
 use std::iter::zip;
 use std::path::{Path, PathBuf};
-use std::process::{exit, Output};
-use std::{fs, hash};
+use std::process::exit;
 
-use anyhow::{anyhow, Context, Error, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::{ArgGroup, Args, Parser, Subcommand};
 use log::LevelFilter;
-use srtlib::Subtitles as SrtSubtitles;
 use subbub::core::data::{hash_subtitles, is_video_file, SyncTool, VideoSource};
 use subbub::core::data::{list_subtitles_files, list_video_files, TMP_DIRECTORY};
 use subbub::core::data::{ShiftDirection, SubtitleSource};
-use subbub::core::ffmpeg::read_subtitles_file;
 use subbub::core::log::initialize_logging;
 use subbub::core::merge::merge;
 use subbub::core::modify::{self, strip_html};

--- a/src/bin/subbub.rs
+++ b/src/bin/subbub.rs
@@ -8,12 +8,11 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::{fs, hash};
 
-use anyhow::{anyhow, Error};
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use clap::{ArgGroup, Args, Parser, Subcommand};
 use log::LevelFilter;
 use srtlib::Subtitles as SrtSubtitles;
-use subbub::core::data::{hash_subtitles, is_video_file, SyncTool};
+use subbub::core::data::{hash_subtitles, is_video_file, SyncTool, VideoSource};
 use subbub::core::data::{list_subtitles_files, list_video_files, TMP_DIRECTORY};
 use subbub::core::data::{ShiftDirection, SubtitleSource};
 use subbub::core::ffmpeg::read_subtitles_file;
@@ -56,12 +55,26 @@ struct SubtitleArgs {
     subtitles: String,
 }
 
+impl SubtitleArgs {
+    /// parses the input subtitles path and returns a `SubtitleSource`
+    fn parse(&self) -> Result<SubtitleSource> {
+        SubtitleSource::try_from(self.subtitles.as_str())
+    }
+}
+
 #[derive(Args, Debug)]
 #[clap(group(ArgGroup::new("video").required(true).multiple(false)))]
 struct VideoArgs {
     /// the input file or directory containing video file(s)
     #[arg(short = 'v', long, verbatim_doc_comment)]
     video: String,
+}
+
+impl VideoArgs {
+    /// parses the input video path and returns a `PathBuf`
+    fn parse(&self) -> Result<VideoSource> {
+        VideoSource::try_from(self.video.as_str())
+    }
 }
 
 #[derive(Args, Debug)]

--- a/src/bin/subbub.rs
+++ b/src/bin/subbub.rs
@@ -10,7 +10,7 @@ use std::{fs, hash};
 
 use anyhow::{anyhow, Error};
 use anyhow::{Context, Result};
-use clap::{Args, Parser, Subcommand};
+use clap::{ArgGroup, Args, Parser, Subcommand};
 use log::LevelFilter;
 use srtlib::Subtitles as SrtSubtitles;
 use subbub::core::data::{hash_subtitles, is_video_file, SyncTool};
@@ -48,15 +48,45 @@ enum Commands {
 }
 
 #[derive(Args, Debug)]
+#[clap(group(ArgGroup::new("subtitle").required(true).multiple(false)))]
+struct SubtitleArgs {
+    /// the input file or directory containing subtitles
+    /// for subtitle tracks contained video files, use the format {filename}:{track_number}
+    #[arg(short = 's', long, verbatim_doc_comment)]
+    subtitles: String,
+}
+
+#[derive(Args, Debug)]
+#[clap(group(ArgGroup::new("video").required(true).multiple(false)))]
+struct VideoArgs {
+    /// the input file or directory containing video file(s)
+    #[arg(short = 'v', long, verbatim_doc_comment)]
+    video: String,
+}
+
+#[derive(Args, Debug)]
+#[clap(group(ArgGroup::new("output").required(true).multiple(false)))]
+struct OutputArgs {
+    /// the output file or directory where the modified entities will be saved
+    #[arg(short = 'o', long, verbatim_doc_comment)]
+    output: PathBuf,
+}
+
+#[derive(Args, Debug)]
+#[clap(group(ArgGroup::new("language_code").required(true).multiple(false)))]
+struct LanguageCodeArgs {
+    /// the language code to assign to the subtitle track(s)
+    #[arg(short = 'l', long, verbatim_doc_comment)]
+    language_code: String,
+}
+
+#[derive(Args, Debug)]
 #[clap(alias = "subs")]
 struct Subtitles {
     /// the subtitles used as input
     /// this may be a subtitles file, a video file, or a directory containing either subtitles files or video files
     #[arg(short = 'i', long, verbatim_doc_comment)]
-    input: PathBuf,
-    /// the subtitles track to use if the input is a video
-    #[arg(short = 't', long, verbatim_doc_comment)]
-    track: Option<u32>,
+    input: String,
     /// the location to output the modified subtitles
     /// if the input contains multiple subtitles, this will be considered a directory, otherwise, a filename
     #[arg(short = 'o', long, verbatim_doc_comment)]

--- a/src/core/data.rs
+++ b/src/core/data.rs
@@ -1,13 +1,12 @@
 use crate::core::ffmpeg;
-use anyhow::{Error, Result};
+use anyhow::Result;
 use clap::ValueEnum;
 use once_cell::sync::{Lazy, OnceCell};
 use serde::{Deserialize, Serialize};
 use srtlib::Subtitles;
 use std::{
-    fmt::Display,
     hash::{DefaultHasher, Hash, Hasher},
-    path::{self, Path, PathBuf},
+    path::{Path, PathBuf},
     process::{Command, Output},
 };
 

--- a/src/core/data.rs
+++ b/src/core/data.rs
@@ -86,6 +86,41 @@ pub enum SubtitleSource {
     },
 }
 
+impl From<String> for SubtitleSource {
+    fn from(s: String) -> Self {
+        // if the string contains a ":" character, we parse it as a video track
+        if s.contains(':') {
+            let parts: Vec<&str> = s.split(':').collect();
+            if parts.len() != 2 {
+                panic!("Invalid video track format: {}", s);
+            }
+            let video_file = PathBuf::from(parts[0]);
+            let subtitle_track: u32 = parts[1].parse().expect("Invalid subtitle track number");
+            return SubtitleSource::VideoTrack {
+                video_file,
+                subtitle_track,
+            };
+        }
+        // otherwise, we assume it's a file path
+        else {
+            let pathbuf = PathBuf::from(s);
+            SubtitleSource::File(pathbuf)
+        }
+    }
+}
+
+impl From<SubtitleSource> for String {
+    fn from(source: SubtitleSource) -> Self {
+        match source {
+            SubtitleSource::File(pathbuf) => pathbuf.to_string_lossy().to_string(),
+            SubtitleSource::VideoTrack {
+                video_file,
+                subtitle_track,
+            } => format!("{}:{}", video_file.to_string_lossy(), subtitle_track),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, ValueEnum, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum SyncTool {

--- a/src/core/data.rs
+++ b/src/core/data.rs
@@ -224,6 +224,26 @@ impl DiskSubtitles {
     }
 }
 
+impl PartialEq for DiskSubtitles {
+    fn eq(&self, other: &Self) -> bool {
+        self.path == other.path
+    }
+}
+
+impl PartialOrd for DiskSubtitles {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.path.partial_cmp(&other.path)
+    }
+}
+
+impl Eq for DiskSubtitles {}
+
+impl Ord for DiskSubtitles {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.path.cmp(&other.path)
+    }
+}
+
 impl SubtitleSource {
     pub fn to_subtitles(&self) -> Result<Vec<DiskSubtitles>> {
         match self {

--- a/src/core/data.rs
+++ b/src/core/data.rs
@@ -1,5 +1,5 @@
 use crate::core::ffmpeg;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::ValueEnum;
 use once_cell::sync::{Lazy, OnceCell};
 use serde::{Deserialize, Serialize};
@@ -276,7 +276,8 @@ impl SubtitleSource {
                     let entry = entry?;
                     let path = entry.path();
                     if is_subtitle_file(&path) {
-                        let s = Subtitles::parse_from_file(&path, None)?;
+                        let s = Subtitles::parse_from_file(&path, None)
+                            .context(format!("failed to parse subtitle file {path:#?}"))?;
                         subtitles.push(DiskSubtitles {
                             path: path.to_owned(),
                             subtitles: s,

--- a/src/core/ffmpeg.rs
+++ b/src/core/ffmpeg.rs
@@ -117,7 +117,8 @@ pub fn read_subtitles_file(path: &Path) -> Result<Subtitles> {
     log::trace!("{0}", pretty_output(&output));
 
     log::debug!("reading from temporary file {tmp_file:#?} converted from {path:#?}");
-    let subs = Subtitles::parse_from_file(tmp_file, None)?;
+    let subs = Subtitles::parse_from_file(&tmp_file, None)
+        .context(format!("could not parse subtitle file {tmp_file:#?}"))?;
 
     Ok(subs)
 }

--- a/src/core/merge.rs
+++ b/src/core/merge.rs
@@ -29,7 +29,9 @@ pub fn merge(primary: &Subtitles, secondary: &Subtitles) -> Result<Subtitles> {
     Ok(merged)
 }
 
-fn modify_positioning(sub: &mut Subtitle, primary: bool) -> Result<()> {
+// TODO: remove this allow once the function is implemented
+#[allow(dead_code)]
+fn modify_positioning(_sub: &mut Subtitle, _primary: bool) -> Result<()> {
     // ass/ssa specification: http://www.tcax.org/docs/ass-specs.htm
     // in particular:
 
@@ -51,5 +53,4 @@ fn modify_positioning(sub: &mut Subtitle, primary: bool) -> Result<()> {
     // \an<alignment>         numpad layout
     // Only the first appearance counts.
     todo!();
-    Ok(())
 }

--- a/src/core/mkvmerge.rs
+++ b/src/core/mkvmerge.rs
@@ -1,10 +1,8 @@
-use anyhow::{anyhow, Context, Result};
-use srtlib::Subtitles;
+use anyhow::{anyhow, Result};
+
 use std::{path::Path, process::Command};
 
-use crate::core::data::{pretty_cmd, pretty_output, TMP_DIRECTORY};
-
-use super::data::hash_string;
+use crate::core::data::{pretty_cmd, pretty_output};
 
 pub fn add_subtitles_track(
     video_file: &Path,

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use srtlib::Subtitles;
-use std::{hash, path::Path, process::Command};
+use std::process::Command;
 
 use crate::core::data::{pretty_cmd, pretty_output};
 


### PR DESCRIPTION
Refactors the CLI such that inputs are standardized and easily discoverable

To demonstrate, here's an example:

`subbub subtitles -i abc.srt -o ./ouput_dir/ strip_html` -> `subbub subtitles strip_html -s abc.srt -o ./output_dir/`

The subtitles command no longer takes some arguments for itself

Inputting subtitles from video files has also been simplified and the internal logic has been streamlined